### PR TITLE
Merge Thalemine 1.10.0 release into stable

### DIFF
--- a/bio/webapp/src/org/intermine/bio/web/displayer/FriendlyMineLinkGenerator.java
+++ b/bio/webapp/src/org/intermine/bio/web/displayer/FriendlyMineLinkGenerator.java
@@ -140,14 +140,28 @@ public final class FriendlyMineLinkGenerator implements InterMineLinkGenerator
 
         private PathQuery getHomologueQuery(Mine mine, ObjectRequest req) {
             PathQuery q = new PathQuery(mine.getModel());
-            q.addViews(
-                "Gene.homologues.homologue.primaryIdentifier",
-                "Gene.homologues.homologue.symbol",
-                "Gene.homologues.homologue.organism.shortName"
-            );
-            q.addOrderBy("Gene.homologues.homologue.organism.shortName", OrderDirection.ASC);
-            q.addConstraint(Constraints.lookup("Gene", req.getIdentifier(), req.getDomain()));
-            q.addConstraint(Constraints.neq("Gene.homologues.type", "paralogue"));
+            if (mine.getLinkClasses().contains("phytomineHomolog")) {
+                // query for phytomine homolog data model
+                q.addViews(
+                        "Gene.homolog.gene2.primaryIdentifier",
+                        "Gene.homolog.gene2.symbol",
+                        "Gene.homolog.gene2.organism.shortName"
+                );
+                q.addOrderBy("Gene.homolog.gene2.primaryIdentifier", OrderDirection.ASC);
+                q.addConstraint(Constraints.lookup("Gene.homolog.gene1", req.getIdentifier(), req.getDomain()), "A");
+                q.addConstraint(Constraints.neq("Gene.homolog.gene2.organism.shortName", req.getDomain()), "B");
+                q.setConstraintLogic("A and B");
+            } else {
+                // query for the standard homologue data model
+                q.addViews(
+                    "Gene.homologues.homologue.primaryIdentifier",
+                    "Gene.homologues.homologue.symbol",
+                    "Gene.homologues.homologue.organism.shortName"
+                );
+                q.addOrderBy("Gene.homologues.homologue.organism.shortName", OrderDirection.ASC);
+                q.addConstraint(Constraints.lookup("Gene", req.getIdentifier(), req.getDomain()));
+                q.addConstraint(Constraints.neq("Gene.homologues.type", "paralogue"));
+            }
             return q;
         }
 

--- a/intermine/api/main/src/org/intermine/api/mines/LocalMine.java
+++ b/intermine/api/main/src/org/intermine/api/mines/LocalMine.java
@@ -40,6 +40,7 @@ public class LocalMine implements ConfigurableMine
     private final String url;
     private final String release;
     private final Set<String> defaultValues = new LinkedHashSet<String>();
+    private final Set<String> linkClasses = new LinkedHashSet<String>();
     private String logo;
     private String bgcolor;
     private String frontcolor;
@@ -71,6 +72,7 @@ public class LocalMine implements ConfigurableMine
     public void configure(Properties props) {
         logo = props.getProperty("logo");
         defaultValues.addAll(Arrays.asList(props.getProperty("defaultValues").split(",")));
+        linkClasses.addAll(Arrays.asList(props.getProperty("linkClasses", "").split(",")));
         bgcolor = props.getProperty("bgcolor");
         frontcolor = props.getProperty("frontcolor");
         description = props.getProperty("description");
@@ -132,6 +134,19 @@ public class LocalMine implements ConfigurableMine
     public String getDefaultValue() {
         if (defaultValues != null && !defaultValues.isEmpty()) {
             return defaultValues.iterator().next();
+        }
+        return null;
+    }
+
+    @Override
+    public Set<String> getLinkClasses() {
+        return linkClasses;
+    }
+
+    @Override
+    public String getLinkClass() {
+        if (linkClasses != null && !linkClasses.isEmpty()) {
+            return linkClasses.iterator().next();
         }
         return null;
     }

--- a/intermine/api/main/src/org/intermine/api/mines/Mine.java
+++ b/intermine/api/main/src/org/intermine/api/mines/Mine.java
@@ -78,6 +78,17 @@ public interface Mine
     String getDefaultValue();
 
     /**
+     * @return the linkClass
+     */
+    Set<String> getLinkClasses();
+
+    /**
+     * get first link class. used in remotemine to build specific link types
+     * @return the linkClass
+     */
+    String getLinkClass();
+
+    /**
      * Run a path query and get back all the results.
      * @param query The query to run.
      * @return A list of rows.

--- a/intermine/api/main/src/org/intermine/api/mines/RemoteMine.java
+++ b/intermine/api/main/src/org/intermine/api/mines/RemoteMine.java
@@ -58,6 +58,7 @@ public class RemoteMine implements ConfigurableMine
     private String url;
     private String logo;
     private Set<String> defaultValues = new HashSet<String>();
+    private Set<String> linkClasses = new HashSet<String>();
     private String bgcolor;
     private String frontcolor;
     private String description;
@@ -88,6 +89,7 @@ public class RemoteMine implements ConfigurableMine
         url = props.getProperty("url");
         logo = props.getProperty("logo");
         defaultValues.addAll(Arrays.asList(props.getProperty("defaultValues", "").split(",")));
+        linkClasses.addAll(Arrays.asList(props.getProperty("linkClasses", "homologue").split(",")));
         bgcolor = props.getProperty("bgcolor");
         frontcolor = props.getProperty("frontcolor");
         description = props.getProperty("description");
@@ -194,6 +196,19 @@ public class RemoteMine implements ConfigurableMine
     @Override
     public String getDefaultValue() {
         for (String value : defaultValues) {
+            return value;
+        }
+        return null;
+    }
+
+    @Override
+    public Set<String> getLinkClasses() {
+        return linkClasses;
+    }
+
+    @Override
+    public String getLinkClass() {
+        for (String value : linkClasses) {
             return value;
         }
         return null;

--- a/intermine/webapp/main/resources/webapp/otherMinesLink.jsp
+++ b/intermine/webapp/main/resources/webapp/otherMinesLink.jsp
@@ -5,8 +5,7 @@
 <%@ taglib uri="/WEB-INF/functions.tld" prefix="imf" %>
 
 <!-- This section is rendered with Ajax to improve responsiveness -->
-<c:if test="${!empty mines && imf:hasValidPath(object, 'organism.shortName', INTERMINE_API)
-&& !fn:startsWith(object, 'Generif')}">
+<c:if test="${!empty mines && imf:hasValidPath(object, 'organism.shortName', INTERMINE_API)}"></c:if>
 <script type="text/javascript" charset="utf-8" src="js/other-mines-links.js"></script>
 <h3 class="goog"><fmt:message key="othermines.title"/></h3>
 <div id="friendlyMines">

--- a/intermine/webapp/main/resources/webapp/otherMinesLink.jsp
+++ b/intermine/webapp/main/resources/webapp/otherMinesLink.jsp
@@ -5,7 +5,7 @@
 <%@ taglib uri="/WEB-INF/functions.tld" prefix="imf" %>
 
 <!-- This section is rendered with Ajax to improve responsiveness -->
-<c:if test="${!empty mines && imf:hasValidPath(object, 'organism.shortName', INTERMINE_API)}"></c:if>
+<c:if test="${!empty mines && imf:hasValidPath(object, 'organism.shortName', INTERMINE_API)}">
 <script type="text/javascript" charset="utf-8" src="js/other-mines-links.js"></script>
 <h3 class="goog"><fmt:message key="othermines.title"/></h3>
 <div id="friendlyMines">

--- a/thalemine/webapp/resources/model.properties
+++ b/thalemine/webapp/resources/model.properties
@@ -1,7 +1,7 @@
 # Model specific internationalisation properties
 # this file merges with InterMineWebApp.properties
 
-funding = The Arabidopsis Information Portal is funded by a grant from the National Science Foundation (<a href="http://www.nsf.gov/awardsearch/showAward?AWD_ID=1262414" target="_blank">#DBI-1262414</a>)<br /> and co-funded by a grant from the Biotechnology and Biological Sciences Research Council (<a href="http://www.bbsrc.ac.uk/pa/grants/AwardDetails.aspx?FundingReference=BB/L027151/1" target="_blank">BB/L027151/1</a>)<br />
+funding = <p>The Arabidopsis Information Portal is funded by a grant from the National Science Foundation (<a href="http://www.nsf.gov/awardsearch/showAward?AWD_ID=1262414" target="_blank">#DBI-1262414</a>)<br /> and co-funded by a grant from the Biotechnology and Biological Sciences Research Council (<a href="http://www.bbsrc.ac.uk/pa/grants/AwardDetails.aspx?FundingReference=BB/L027151/1" target="_blank">BB/L027151/1</a>)</p><a class="araport-logo" href="https://www.araport.org/" title="Araport - The Arabidopsis Information Portal" target="_blank"><img src="images/icons/araport-footer-logo.png" alt="Araport logo"></a> <a class="jcvi-logo" href="http://www.jcvi.org/" title="J. Craig Venter Institute" target="_blank"><img src="images/icons/jcvi-footer-logo.png" alt="JCVI logo"></a> <a class="tacc-logo" href="https://www.tacc.utexas.edu/" title="Texas Advanced Computing Center" target="_blank"><img src="images/icons/tacc-footer-logo.png" alt="TACC logo"></a> <a class="cambridge-logo" href="http://www.cam.ac.uk/" title="University of Cambridge" target="_blank"><img src="images/icons/cambridge-footer-logo.png" alt="University of Cambridge logo"></a>
 
 fasta.export.classes = SequenceFeature,Protein
 

--- a/thalemine/webapp/resources/web.properties
+++ b/thalemine/webapp/resources/web.properties
@@ -407,7 +407,7 @@ xreflink.BioGRID.url=http://thebiogrid.org/<<attributeValue>>
 #use.localstorage = true
 
 # BAR eFP browser displayer
-bar.eFPBrowser.prefix = https://api.araport.org/community/v0.3/aip/efp_by_locus_v0.2.0/search
+bar.eFPBrowser.prefix = https://apps.araport.org/proxy/bar/efp
 
 # phytomine
 phytomine.homolog.prefix = https://apps.araport.org/proxy/phytozome/phytomine

--- a/thalemine/webapp/resources/web.properties
+++ b/thalemine/webapp/resources/web.properties
@@ -342,13 +342,14 @@ intermines.medicmine.frontcolor=#FFF
 intermines.medicmine.defaultValues=M. truncatula
 intermines.medicmine.description=Medicago truncatula genome database
 
-#intermines.phytomine.url=https://phytozome.jgi.doe.gov/phytomine
-#intermines.phytomine.name=PhytoMine
-#intermines.phytomine.logo=logo.png
-#intermines.phytomine.bgcolor=#6E9E75
-#intermines.phytomine.frontcolor=#FFF
-#intermines.phytomine.defaultValues=A. thaliana,A. lyrata,B. rapa,G. max,M. truncatula,Z. mays
-#intermines.phytomine.description=InterMine interface to data from Phytozome
+intermines.phytomine.url=https://phytozome.jgi.doe.gov/phytomine
+intermines.phytomine.name=PhytoMine
+intermines.phytomine.logo=logo.png
+intermines.phytomine.bgcolor=#6E9E75
+intermines.phytomine.frontcolor=#FFF
+intermines.phytomine.defaultValues=A. thaliana,A. lyrata,B. rapa,G. max
+intermines.phytomine.description=InterMine interface to data from Phytozome
+intermines.phytomine.linkClasses=phytomineHomolog
 
 intermines.beanmine.url=http://mines.legumeinfo.org/beanmine
 intermines.beanmine.name=BeanMine

--- a/thalemine/webapp/resources/web.properties
+++ b/thalemine/webapp/resources/web.properties
@@ -471,3 +471,6 @@ by replying to this email or by using the links found at the bottom of each page
 Best wishes,\n\
 \n\
 The %1$s team.
+
+# citation
+project.citation=<a href="http://dx.doi.org/10.1093/nar/gku1200" target="_blank">Krishnakumar, V. et al. Araport: the Arabidopsis Information Portal. Nucl. Acids Res. 43 (D1): D1003-D1009.</a>

--- a/thalemine/webapp/resources/web.properties
+++ b/thalemine/webapp/resources/web.properties
@@ -266,7 +266,7 @@ project.siteLogo=https://s.gravatar.com/avatar/978e836a9d65238a784543ad932637cd.
 project.helpLocation=https://www.araport.org/thalemine/user-guide
 
 araport.attribution=<strong><i>Source:&nbsp;</i></strong><a target="_blank" href="portal.do?class=DataSet&externalids=Genome+Annotation">Araport11</a> (06/2016).
-tair.attribution=<strong><i>Source:&nbsp;</i></strong><a target="_blank" href="portal.do?class=DataSet&externalids=Gene+Summary">TAIR</a>, Mar 31, 2015.
+tair.attribution=<strong><i>Source:&nbsp;</i></strong><a target="_blank" href="portal.do?class=DataSet&externalids=Gene+Summary">TAIR</a>, Jun 30, 2015.
 
 
 

--- a/thalemine/webapp/resources/web.properties
+++ b/thalemine/webapp/resources/web.properties
@@ -410,7 +410,7 @@ xreflink.BioGRID.url=http://thebiogrid.org/<<attributeValue>>
 bar.eFPBrowser.prefix = https://api.araport.org/community/v0.3/aip/efp_by_locus_v0.2.0/search
 
 # phytomine
-phytomine.homolog.prefix = https://api.araport.org/community/v0.3/phytozome/phytomine_v0.2/access
+phytomine.homolog.prefix = https://apps.araport.org/proxy/phytozome/phytomine
 phytomine.url = https://phytozome.jgi.doe.gov/phytomine/
 
 #Panther Direct Link
@@ -447,7 +447,7 @@ jwt.verification.strategy=ANY
 authentication.identity.assertion.header=X-Jwt-Assertion-Araport-Org
 
 # ATTED configuration
-atted.url.prefix=https://api.araport.org/community/v0.3/atted/atted_coex_v1.1/access
+atted.url.prefix=https://apps.araport.org/proxy/atted/API/coex
 
 # Araport anonymous user accessToken
 araport.accessToken=5560c37c792ccffa231b855c43d57ea

--- a/thalemine/webapp/resources/web.properties
+++ b/thalemine/webapp/resources/web.properties
@@ -347,7 +347,7 @@ intermines.phytomine.name=PhytoMine
 intermines.phytomine.logo=logo.png
 intermines.phytomine.bgcolor=#6E9E75
 intermines.phytomine.frontcolor=#FFF
-intermines.phytomine.defaultValues=A. thaliana,A. lyrata,B. rapa,G. max
+intermines.phytomine.defaultValues=A. thaliana,A. trichopoda,A. lyrata,B. rapa FPsc,G. max,O. sativa,P. trichocarpa,Z. mays
 intermines.phytomine.description=InterMine interface to data from Phytozome
 intermines.phytomine.linkClasses=phytomineHomolog
 

--- a/thalemine/webapp/resources/web.properties
+++ b/thalemine/webapp/resources/web.properties
@@ -351,26 +351,26 @@ intermines.phytomine.defaultValues=A. thaliana,A. trichopoda,A. lyrata,B. rapa F
 intermines.phytomine.description=InterMine interface to data from Phytozome
 intermines.phytomine.linkClasses=phytomineHomolog
 
-intermines.beanmine.url=http://mines.legumeinfo.org/beanmine
-intermines.beanmine.name=BeanMine
-intermines.beanmine.bgcolor=#93C76A
-intermines.beanmine.frontcolor=#FFF
-intermines.beanmine.defaultValues=P. vulgaris
-intermines.beanmine.description=LIS string bean mine
-
-intermines.soymine.name=SoyMine
-intermines.soymine.url=http://mines.legumeinfo.org/soymine
-intermines.soymine.bgcolor=#9F9060
-intermines.soymine.frontcolor=#FFF
-intermines.soymine.defaultValues=G. max
-intermines.soymine.description=LIS soybean mine
-
-intermines.peanutmine.name=PeanutMine
-intermines.peanutmine.url=http://mines.legumeinfo.org/peanutmine
-intermines.peanutmine.bgcolor=#CCC
-intermines.peanutmine.frontcolor=#FFF
-intermines.peanutmine.defaultValues=A. duranensis,A. ipaensis
-intermines.peanutmine.description=LIS peanut mine
+##intermines.beanmine.url=http://mines.legumeinfo.org/beanmine
+##intermines.beanmine.name=BeanMine
+##intermines.beanmine.bgcolor=#93C76A
+##intermines.beanmine.frontcolor=#FFF
+##intermines.beanmine.defaultValues=P. vulgaris
+##intermines.beanmine.description=LIS string bean mine
+##
+##intermines.soymine.name=SoyMine
+##intermines.soymine.url=http://mines.legumeinfo.org/soymine
+##intermines.soymine.bgcolor=#9F9060
+##intermines.soymine.frontcolor=#FFF
+##intermines.soymine.defaultValues=G. max
+##intermines.soymine.description=LIS soybean mine
+##
+##intermines.peanutmine.name=PeanutMine
+##intermines.peanutmine.url=http://mines.legumeinfo.org/peanutmine
+##intermines.peanutmine.bgcolor=#CCC
+##intermines.peanutmine.frontcolor=#FFF
+##intermines.peanutmine.defaultValues=A. duranensis,A. ipaensis
+##intermines.peanutmine.description=LIS peanut mine
 
 # to redirect links
 webapp.linkRedirect=org.intermine.bio.web.BioLinkRedirectManager

--- a/thalemine/webapp/resources/webapp/WEB-INF/webconfig-model.xml
+++ b/thalemine/webapp/resources/webapp/WEB-INF/webconfig-model.xml
@@ -647,11 +647,13 @@
                      placement="Genomics"
                      types="SequenceFeature"/>
 
+    <!-- Temporarily disable the TDNA-seq insertions displayer
     <reportdisplayer javaClass="org.thalemine.web.displayer.TdnaseqInsertionsDisplayer"
                      jspName="model/tdnaseqInsertionsDisplayer.jsp"
                      replacesFields=""
                      placement="Genomics"
                      types="Gene,Transcript"/>
+    -->
 
 <!-- PROTEINS -->
     <reportdisplayer javaClass="org.thalemine.web.displayer.ProteinDisplayer"

--- a/thalemine/webapp/resources/webapp/WEB-INF/webconfig-model.xml
+++ b/thalemine/webapp/resources/webapp/WEB-INF/webconfig-model.xml
@@ -115,6 +115,9 @@
       <fieldconfig fieldExpr="briefDescription"/>
       <fieldconfig fieldExpr="isObsolete" label="Is Obsolete?"/>
     </fields>
+    <bagdisplayers>
+      <bagdisplayer src="friendlyMineLinkDisplayer.tile" showOnLeft="false" />
+    </bagdisplayers>
   </class>
 
   <class className="org.intermine.model.bio.GeneFlankingRegion">

--- a/thalemine/webapp/resources/webapp/footer.jsp
+++ b/thalemine/webapp/resources/webapp/footer.jsp
@@ -1,4 +1,3 @@
-<!doctype html>
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib uri="/WEB-INF/struts-tiles.tld" prefix="tiles" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -6,14 +5,10 @@
 
 <!-- footer.jsp -->
 <br/>
+<br/>
+<br/>
 
 <div class="body" align="center" style="clear:both">
-    <!-- powered -->
-    <p>Powered by</p>
-    <a target="new" href="http://intermine.org" title="InterMine">
-        <img src="images/icons/intermine-footer-logo.png" alt="InterMine logo" />
-    </a>
-
     <!-- contact -->
     <c:if test="${pageName != 'contact'}">
         <div id="contactFormDivButton">
@@ -30,47 +25,39 @@
         </div>
     </c:if>
     <br/>
-</div>
 
-<div class="body bottom-footer">
-    <!-- funding -->
-    <div align="center" class="body funding-footer">
-        <fmt:message key="funding" />
+<div id="promo-footer">
+  <!-- powered -->
+  <div class="powered-footer footer">
+    <p>Powered by</p>
+    <a target="new" href="http://intermine.org" title="InterMine">
+      <img src="images/icons/intermine-footer-logo.png" alt="InterMine logo" />
+    </a>
+  </div>
+    <div class="android">
+        <p>Have you tried our InterMine Android app?</p>
+        <a href='https://play.google.com/store/apps/details?id=org.intermine.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1' target="_blank"><img class="googleplay" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' /></a>
     </div>
-
-<div align="center" class="body funding-footer">
-<!-- cam logo and links -->
-<table>
-  <tr><td>
-    <a class="araport-logo" href="https://www.araport.org/" title="Araport - The Arabidopsis Information Portal" target="_blank">
-        <img src="images/icons/araport-footer-logo.png" alt="Araport logo">
-    </a>
-    </td><td>
-     <a class="jcvi-logo" href="http://www.jcvi.org/" title="J. Craig Venter Institute" target="_blank">
-        <img src="images/icons/jcvi-footer-logo.png" alt="JCVI logo">
-    </a>
-    </td><td>
-     <a class="tacc-logo" href="https://www.tacc.utexas.edu/" title="Texas Advanced Computing Center" target="_blank">
-        <img src="images/icons/tacc-footer-logo.png" alt="TACC logo">
-    </a>
-    </td><td>
-    <a class="cambridge-logo" href="http://www.cam.ac.uk/" title="University of Cambridge" target="_blank">
-        <img src="images/icons/cambridge-footer-logo.png" alt="University of Cambridge logo">
-    </a>
-  </td></tr>
-</table>
-
-
-
-
-<!--
-    <a class="tacc-logo" href="http://www.cam.ac.uk/" title="University of Cambridge" target="_blank">
-        <img src="model/images/tacc-footer-logo.png" alt="University of Cambridge logo">
-    </a>
--->
+    <div class="cite-footer footer">
+      <strong>Cite us:</strong>
+          <cite>${WEB_PROPERTIES['project.citation']}</cite>
+    </div>
 </div>
-    <ul class="footer-links">
+<div class="funding-footer footer">
+  <!-- funding -->
+  <div class="funders"><fmt:message key="funding" /></div>
+  <!--div class="credits"><fmt:message key="credits" /></div-->
+</div>
 
+</div>
+
+<!-- cam logo and links -->
+<div class="body bottom-footer">
+    <!--a class="cambridge-logo" href="http://www.cam.ac.uk/" title="University of Cambridge" target="_blank">
+        <img src="images/icons/cambridge-footer-logo.png" alt="University of Cambridge logo">
+    </a-->
+
+    <ul class="footer-links">
         <!-- contact us form link -->
         <li><a href="#" onclick="showContactForm();return false;">Contact Us</a></li>
         <c:set value="${WEB_PROPERTIES['header.links']}" var="headerLinks"/>
@@ -86,7 +73,23 @@
                 </c:otherwise>
             </c:choose>
         </c:forEach>
+
     </ul>
+
+    <!-- mines -->
+    <!--ul class="footer-links">
+        <li><a href="http://www.intermine.org" target="_blank">InterMine</a></li>
+        <li><a href="http://www.flymine.org" target="_blank">FlyMine</a></li>
+        <li><a href="http://www.mousemine.org" target="_blank">MouseMine</a></li>
+        <li><a href="http://ratmine.mcw.edu/ratmine" target="_blank">RatMine</a></li>
+        <li><a href="http://www.wormbase.org/tools/wormmine" target="_blank">WormMine</a></li>
+        <li><a href="http://yeastmine.yeastgenome.org" target="_blank">YeastMine</a></li>
+        <li><a href="http://www.zebrafishmine.org" target="_blank">ZebrafishMine</a></li>
+        <li><a href="http://www.humanmine.org" target="_blank">HumanMine</a></li>
+    </ul-->
+
+    <!--p class="footer-copy">&copy; 2002 - 2016 Department of Genetics, University of Cambridge, Downing Street,<br />
+        Cambridge CB2 3EH, United Kingdom</p-->
 
     <div style="clear:both"></div>
 </div>

--- a/thalemine/webapp/resources/webapp/footer.jsp
+++ b/thalemine/webapp/resources/webapp/footer.jsp
@@ -46,7 +46,6 @@
 <div class="funding-footer footer">
   <!-- funding -->
   <div class="funders"><fmt:message key="funding" /></div>
-  <!--div class="credits"><fmt:message key="credits" /></div-->
 </div>
 
 </div>

--- a/thalemine/webapp/resources/webapp/headMenu.jsp
+++ b/thalemine/webapp/resources/webapp/headMenu.jsp
@@ -105,6 +105,7 @@
       </li>
     </ul>
   <ul id="loginbar">
+        <li><a href="https://www.araport.org" target="_blank" alt="Araport - Arabidopsis Information Portal">Araport Home</a></li>
         <li><a href="#" onclick="showContactForm();return false;"><fmt:message key="feedback.link"/></a></li>
         <c:if test="${PROFILE.loggedIn}">
             <li>

--- a/thalemine/webapp/resources/webapp/model/eFPBrowserDisplayer.jsp
+++ b/thalemine/webapp/resources/webapp/model/eFPBrowserDisplayer.jsp
@@ -89,7 +89,6 @@
         var req_url = bar_eFPBrowser_url + "?locus=" + agi + "&source=" + datasource;
         var request = new XMLHttpRequest();
         request.open('GET', req_url, true);
-        request.setRequestHeader('Authorization', 'Bearer ' + "${WEB_PROPERTIES['araport.accessToken']}");
         request.responseType = 'blob';
         request.onload = function () {
             if (this.status === 200) {

--- a/thalemine/webapp/resources/webapp/model/phytomineOrthologDisplayer.jsp
+++ b/thalemine/webapp/resources/webapp/model/phytomineOrthologDisplayer.jsp
@@ -37,9 +37,8 @@
    // for local test only
    // var webapp_root_url="http://phytozome.jgi.doe.gov/phytomine/";
    var webapp_root_url = "${WEB_PROPERTIES['phytomine.homolog.prefix']}";
-   var bearer_token = "Bearer ${WEB_PROPERTIES['araport.accessToken']}";
 
-   var phytomine = new imjs.Service({root: webapp_root_url, headers: { "Authorization": bearer_token }});
+   var phytomine = new imjs.Service({root: webapp_root_url});
 
    var options = {
      type: 'table',

--- a/thalemine/webapp/resources/webapp/report.jsp
+++ b/thalemine/webapp/resources/webapp/report.jsp
@@ -576,13 +576,10 @@ var type="${TYPE}";   // the root for the ws query
     </tiles:insert>
   </div>
 
-  <c:set var="getFriendly" value="yes"></c:set>
-    <c:if test="${object.type == 'Stock' || object.type == 'Allele' ||
-                  object.type == 'Phenotype' || object.type == 'Genotype' ||
-                  object.type == 'Transcript' || object.type == 'Protein' ||
-                  object.type == 'TransposableElementInsertionSite'}">
-     <c:set var="getFriendly" value="no"></c:set>
-    </c:if>
+  <c:set var="getFriendly" value="no"></c:set>
+  <c:if test="${fn:endsWith(fn:toLowerCase(object.type), 'gene')}">
+     <c:set var="getFriendly" value="yes"></c:set>
+  </c:if>
   <c:set var="object_bk" value="${object}"/>
   <c:set var="object" value="${reportObject.object}" scope="request"/>
   <div id="external-links">


### PR DESCRIPTION
This PR merges changes made to ThaleMine (webapp only) as part of incremental updates to the ThaleMine 1.10.0 release.

ThaleMine 1.10.0 was initially deployed in August 2016.

1. Webapp was updated in September 2016 to use Araport proxy URLs to ATTED/PhytoMine/BAR instead of via Adama.
2. Webapp was updated in October 2016 to disable the TDNA-Seq insertions displayer (since the data is already visible via Overlapping Features)
3. Finally, webapp was updated in December 2016 to add support to generate FriendlyMine links to PhytoMine. LegFed mines were disable due to incompatible Arabidopsis feature identifiers.
